### PR TITLE
adding spacer columns, fixes #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "griddle-position-plugin",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "A plugin for partial rendering of data.",
   "main": "./build/griddle-position-plugin.js",
   "scripts": {

--- a/src/components/spacer-row.js
+++ b/src/components/spacer-row.js
@@ -11,7 +11,7 @@ class SpacerRow extends React.Component {
 
   render() {
     let height = 0, spacerRowStyle = {};
-    const { placement, currentPosition, positionConfig } = this.props;
+    const {placement, currentPosition, positionConfig, renderProperties} = this.props;
 
     if (currentPosition) {
       // Get the length of rows that the spacer row will represent.
@@ -24,7 +24,11 @@ class SpacerRow extends React.Component {
 
     spacerRowStyle.height = height + 'px';
     return (
-      <tr key={placement + '-' + height} style={spacerRowStyle} />
+      <tr key={placement + '-' + height} style={spacerRowStyle}>
+        {Object.keys(renderProperties.columnProperties).map(columnName => {
+          return <td key={columnName} style={{width: renderProperties.columnProperties[columnName].width || 'auto'}}></td>
+        })}
+      </tr>
     );
   }
 }


### PR DESCRIPTION
When a table is rendered with `table-layout: fixed` it relies on each column specifying
it's width. When some rows have a different number of columns the layout breaks and
reverts to evenly spaced rows, even when column widths are specified.
<img width="683" alt="screen shot 2016-02-17 at 4 14 08 pm" src="https://cloud.githubusercontent.com/assets/2466842/13129389/863608ec-d591-11e5-8f3a-6ea84343deca.png">

This fixes #3
