### PR TITLE
Fix a bug where pointer events are not re-enabled if a single scroll event fires.

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -64,9 +64,10 @@ class Table extends React.Component {
     if (event && positionConfig.disablePointerEventsOnScroll) {
       if (!this.state.disablePointerEvents) {
         this.setState({disablePointerEvents: true});
-      } else {
-        this.clearScrolling();
       }
+
+      // Clear disable pointer events after scroll events stop for a period of time.
+      this.clearScrolling();
     }
   }
 


### PR DESCRIPTION
Remove the "else" so we always schedule the pointer events re-enabling event on the first scroll event.
